### PR TITLE
Fix SafeString deprecation warning

### DIFF
--- a/addon/components/read-more.js
+++ b/addon/components/read-more.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
     if (!this.get('isOpen')) {
       styles += ' max-height: ' + this.get('maxHeight') + ';';
     }
-    return new Ember.Handlebars.SafeString(styles);
+    return Ember.String.htmlSafe(styles);
   }),
 
   actions: {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "toggle"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^1.0.2"
   },
   "ember-addon": {


### PR DESCRIPTION
Crazy simple PR that should resolve the deprecation warning I'm experiencing using this add-on within post Ember 2.8.

This does not however, resolve the slew of other dep/warnings, nor does it pass `npm test`.
That I'm 100% welcome to aid in fixing, but I'm not entirely sure where to start, it may just be easier to upgrade this addon (the code is simple enough) to 2.12 and go from there?